### PR TITLE
Update .env.dev

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,7 +1,7 @@
 PORT=5000
 NODE_ENV="development"
 JWT_SECRET="thisismysupersecrettokenjustkidding"
-DATABASE_URL"mongodb://mongo:27017/donut-development"
+DATABASE_URL="mongodb://mongo:27017/donut-development"
 SENDGRID_API_KEY='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'
 SOCKET_PORT=8810
 clientbaseurl = "http://localhost:3000/"


### PR DESCRIPTION
Missing `=` is causing error when `npm run dev` is executed.
I think it was deleted by mistake in #172 